### PR TITLE
Fix verification to use signed image data

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react'
+import React, { useState, useMemo, useEffect } from 'react'
 import { signImage, verifyImage } from './api'
 
 function useFileState() {
@@ -26,7 +26,17 @@ export default function App() {
   const [verifyRes, setVerifyRes] = useState(null)
   const [signed, setSigned] = useState({ name: '', dataUrl: '' })
 
-  const canAct = useMemo(() => !!src.dataUrl && !busy, [src.dataUrl, busy])
+  const canSign = useMemo(() => !!src.dataUrl && !busy, [src.dataUrl, busy])
+  const canVerify = useMemo(
+    () => !busy && (signed.dataUrl || src.dataUrl),
+    [busy, signed.dataUrl, src.dataUrl]
+  )
+
+  useEffect(() => {
+    setSigned({ name: '', dataUrl: '' })
+    setVerifyRes(null)
+    setStatus('')
+  }, [src.file])
 
   const onSign = async () => {
     if (!src.dataUrl) return
@@ -45,12 +55,15 @@ export default function App() {
   }
 
   const onVerify = async () => {
-    if (!src.dataUrl) return
+    const verifyTarget = signed.dataUrl
+      ? { name: signed.name || src.name, dataUrl: signed.dataUrl }
+      : { name: src.name, dataUrl: src.dataUrl }
+    if (!verifyTarget.dataUrl) return
     setBusy(true)
     setStatus('Verifying...')
     setVerifyRes(null)
     try {
-      const res = await verifyImage({ name: src.name, dataUrl: src.dataUrl })
+      const res = await verifyImage(verifyTarget)
       setVerifyRes(res)
       setStatus(res.ok ? 'Verification PASS' : 'Verification FAIL')
     } catch (e) {
@@ -92,8 +105,8 @@ export default function App() {
           <div className="panel">
             <label><strong>2) Actions</strong></label>
             <div className="actions">
-              <button onClick={onSign} disabled={!canAct}>Sign</button>
-              <button onClick={onVerify} disabled={!canAct}>Verify</button>
+              <button onClick={onSign} disabled={!canSign}>Sign</button>
+              <button onClick={onVerify} disabled={!canVerify}>Verify</button>
             </div>
             <div className="status">{busy ? 'Working...' : status}</div>
             {verifyRes && (


### PR DESCRIPTION
## Summary
- ensure verification uses the signed image data when available
- enable the Verify button whenever either the original or signed data is ready
- reset the signed verification state when a new image is selected so stale results aren't reused

## Testing
- (cd client && npm run build)

------
https://chatgpt.com/codex/tasks/task_e_68e41e9b9c10832c991ae8a0a4014602